### PR TITLE
Feature/inmemory publickey

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,8 @@ The app accepts a few parameters that allow configuration on a server running th
 * *NODE_ENV* - can be set to "development" or "production"
 * *DB_URL* - the full url to the postgres server including the auth details
 * *PORT* - port that the web interface will start and listen on
+* *GOOGLE_CLIENT_ID* - Google Client ID for Google Login
+* *GOOGLE_SECRET_ID* - Google Client SECRET for Google Login
+* *GOOGLE_OAUTH_CALLBACK_URL* - callback for the node. Would be http://{domain}/connect/callback
+* *TUNNEL_SERVER* - Server nodes will connect to, to open up a tunnel
+* *NODE_PUBLIC_KEY* - public key to load into the node from the server

--- a/goddard/handlers/handshake/setup.coffee
+++ b/goddard/handlers/handshake/setup.coffee
@@ -12,82 +12,82 @@ module.exports = exports = (app) ->
 		param_mac_addr 		= req.body.mac
 		param_public_key 	= req.body.key
 
-		# read our key file
-		fs.readFile './public.key', (err, key_str) ->
+		# read in the public key from environ
+		param_public_key = process.env.NODE_PUBLIC_KEY or ''
 
-			# get the highest ports
-			app.get('models').nodes.max('port').then((port) ->
+		# get the highest ports
+		app.get('models').nodes.max('port').then((port) ->
 
-				# check the port
-				if port
-					if port < 15000
-						port = port + 15000
-				else
-					port = 15000
+			# check the port
+			if port
+				if port < 15000
+					port = port + 15000
+			else
+				port = 15000
 
-				# create the node if it doesn't exist
-				app.get('models').nodes.findOrCreate({
+			# create the node if it doesn't exist
+			app.get('models').nodes.findOrCreate({
 
-						where: {
+					where: {
 
-							macaddr: param_mac_addr
+						macaddr: param_mac_addr
 
-						}, 
-						defaults: {
+					}, 
+					defaults: {
 
-							serial: '',
-							groups: [],
-							server: process.env.TUNNEL_SERVER or 'goddard.io.co.za',
-							port: (port + 1),
-							mport: (port + 2),
-							macaddr: param_mac_addr,
-							publickey: param_public_key,
+						serial: '',
+						groups: [],
+						server: process.env.TUNNEL_SERVER or 'goddard.io.co.za',
+						port: (port + 1),
+						mport: (port + 2),
+						macaddr: param_mac_addr,
+						publickey: param_public_key,
 
-							lat: null,
-							lng: null,
+						lat: null,
+						lng: null,
 
-							lastping: new Date()
+						lastping: new Date()
 
-						}
+					}
 
-					}).then((returned_values) ->
+				}).then((returned_values) ->
 
-						# write the key to the autherised hosts
-						fs.appendFile '/home/node/.ssh/authorized_keys', param_public_key + '\n', (err) ->
+					# write the key to the autherised hosts
+					fs.appendFile '/home/node/.ssh/authorized_keys', param_public_key + '\n', (err) ->
 
-							# write the key to allow access
-							console.dir err
+						# write the key to allow access
+						console.dir err
 
-							# get a local obj to work with
-							node_obj = returned_values[0]
-							created = returned_values[1] == true
+						# get a local obj to work with
+						node_obj = returned_values[0]
+						created = returned_values[1] == true
 
-							# update
-							if not node_obj.serial
-								node_obj.serial = S(node_obj.id).padLeft(4, '0').s
+						# update
+						if not node_obj.serial
+							node_obj.serial = S(node_obj.id).padLeft(4, '0').s
 
-							# save it
-							node_obj.save().then ->
+						# save it
+						node_obj.save().then ->
 
-								# get the node
-								node_obj = node_obj.get()
+							# get the node
+							node_obj = node_obj.get()
 
-								# output
-								res.json {
+							# output
+							res.json {
 
-									'name': node_obj.name,
-									'serial': S( node_obj.id ).padLeft(5, '0').s,
-									'port': {
+								'name': node_obj.name,
+								'serial': S( node_obj.id ).padLeft(5, '0').s,
+								'port': {
 
-										'tunnel': node_obj.port,
-										'monitor': node_obj.mport
+									'tunnel': node_obj.port,
+									'monitor': node_obj.mport
 
-									},
-									'uid': node_obj.id,
-									'server': node_obj.server,
-									'publickey': key_str.toString()
+								},
+								'uid': node_obj.id,
+								'server': node_obj.server,
+								'publickey': key_str.toString()
 
-								}
-				)
-
+							}
 			)
+
+		)


### PR DESCRIPTION
To make deployment easier we need to read in the public key for nodes from the Environment variables and updated the variables in the README quickly
