### PR TITLE
Feature/migration cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,14 @@ The app accepts a few parameters that allow configuration on a server running th
 * *GOOGLE_OAUTH_CALLBACK_URL* - callback for the node. Would be http://{domain}/connect/callback
 * *TUNNEL_SERVER* - Server nodes will connect to, to open up a tunnel
 * *NODE_PUBLIC_KEY* - public key to load into the node from the server
+
+
+## Migrations
+
+The Hub was setup using code based migrations that can be run using the following command in the root folder of the app:
+
+````bash
+DB_URL=postgres://user:password@host/databasename node index.js --migrations [--seed]
+````
+
+This will run through the migrations and confirm when done. **--seed** is optional and tells the app to make sure the database is seeded with the default group "Default" and apps ("Captive Portal", "MAMA")

--- a/goddard/handlers/home.coffee
+++ b/goddard/handlers/home.coffee
@@ -1,45 +1,6 @@
 # acts as the homepage for the dashboard
 module.exports = exports = (app) ->
 
-	# runs the db migration
-	app.get '/sync', (req, res) -> 
-		app.get('sequelize_instance').sync({})
-		app.get('models').groups.create({
-
-			id:1, 
-			name:'Default', 
-			description:'Default group',
-			key: 'default'
-		
-		}, null, {validate: false})
-		app.get('models').apps.create({
-
-			id:1, 
-			name:'Captive Portal', 
-			description:'The default captive portal for the Goddard platform.',
-			key: 'captiveportal',
-			slug: 'captive-portal',
-			visible: false,
-			portal: true
-
-		}, null, {validate: false})
-		app.get('models').apps.create({
-
-			id:2, 
-			name:'MAMA', 
-			description:'The Mobile Alliance for Maternal Action (MAMA) is a global movement that seeks to use mobile technologies to improve the health and lives of mothers in developing nations.',
-			key: 'mama',
-			slug: 'mama',
-			visible: true,
-			portal: false
-
-		}, null, {validate: false})
-		app.get('sequelize_instance')
-		.query('INSERT INTO installs(id, "groupId", "appId", "createdAt", "updatedAt") VALUES(1,1,1,now(),now())')
-		app.get('sequelize_instance')
-		.query('INSERT INTO installs(id, "groupId", "appId", "createdAt", "updatedAt") VALUES(1,1,2,now(),now())')
-		res.json { status: 'ok' }
-
 	# the homepage for load balancer
 	app.get '/', app.get('middleware').checkLoggedIn, (req, res) -> 
 

--- a/goddard/main.coffee
+++ b/goddard/main.coffee
@@ -12,8 +12,69 @@ require('./services')(app)
 require('./middleware')(app)
 require('./handlers')(app)
 
-# start the web app
-app.listen process.env.PORT or 4000, ->
+# before we start the web server, listen for migration commands
 
-	# just output that the web server is running
-	console.log 'Running on port ' + (process.env.PORT or 4000)
+# load in the argv's passed
+argv = require('minimist')(process.argv.slice(2));
+
+# should we run the migrations ?
+if argv.migrations == true
+
+	# run the migrations
+	app.get('sequelize_instance').sync({})
+
+	# should we seed ?
+	if argv.seed == true
+		app.get('models').groups.create({
+
+			id:1, 
+			name:'Default', 
+			description:'Default group',
+			key: 'default'
+		
+		}, null, {validate: false})
+		.catch(->)
+		app.get('models').apps.create({
+
+			id:1, 
+			name:'Captive Portal', 
+			description:'The default captive portal for the Goddard platform.',
+			key: 'captiveportal',
+			slug: 'captive-portal',
+			visible: false,
+			portal: true
+
+		}, null, {validate: false})
+		.catch(->)
+		app.get('models').apps.create({
+
+			id:2, 
+			name:'MAMA', 
+			description:'The Mobile Alliance for Maternal Action (MAMA) is a global movement that seeks to use mobile technologies to improve the health and lives of mothers in developing nations.',
+			key: 'mama',
+			slug: 'mama',
+			visible: true,
+			portal: false
+
+		}, null, {validate: false})
+		.catch(->)
+		app.get('sequelize_instance')
+		.query('INSERT INTO installs(id, "groupId", "appId", "createdAt", "updatedAt") VALUES(1,1,1,now(),now())')
+		.catch(->)
+		app.get('sequelize_instance')
+		.query('INSERT INTO installs(id, "groupId", "appId", "createdAt", "updatedAt") VALUES(1,1,2,now(),now())')
+		.catch(->)
+		
+		# debug output
+		console.log('database was synced up')
+
+	# done
+	process.exit(0)
+
+else
+
+	# start the web app
+	app.listen process.env.PORT or 4000, ->
+
+		# just output that the web server is running
+		console.log 'Running on port ' + (process.env.PORT or 4000)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express-session": "^1.10.4",
     "jade": "^1.9.2",
     "lodash": "^3.6.0",
+    "minimist": "^1.1.1",
     "moment": "^2.10.2",
     "pg": "^4.3.0",
     "pg-hstore": "^2.3.1",


### PR DESCRIPTION
Updated to easily run the migrations from the Terminal rather than our quickly put together little hack to run the sync from the browser. Removed the /sync endpoint and updated the README with the details on how to run
