### PR TITLE
Updated to read in the variables for the file paths from the ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The app accepts a few parameters that allow configuration on a server running th
 * *GOOGLE_OAUTH_CALLBACK_URL* - callback for the node. Would be http://{domain}/connect/callback
 * *TUNNEL_SERVER* - Server nodes will connect to, to open up a tunnel
 * *NODE_PUBLIC_KEY* - public key to load into the node from the server
+* *AUTHED_KEYS_FILE* - File to append the public key to, default /home/node/.ssh/authorized_keys
+* *APP_FOLDER_PATH* - Path of the folder that contains the apps, without a trailing slash.
 
 
 ## Migrations

--- a/goddard/handlers/apps/create.coffee
+++ b/goddard/handlers/apps/create.coffee
@@ -4,6 +4,7 @@ module.exports = exports = (app) ->
 	# required modules
 	async = require('async')
 	S = require('string')
+	fs = require('fs')
 
 	# the homepage for load balancer
 	app.get '/apps/create', (req, res) -> 
@@ -25,17 +26,25 @@ module.exports = exports = (app) ->
 		param_visible_str			= req.body.visible
 		param_portal_str			= req.body.portal
 
-		# output
-		group_obj = app.get('models').apps.build({
+		# validate that the folder exists for the app
+		fs.exists process.env.APP_FOLDER_PATH or '/var/goddard/apps', (exists) ->
 
-				name: param_name_str,
-				description: param_description_str,
-				key: param_key_str,
-				visible: param_visible_str == '1',
-				portal: param_portal_str == '1',
-				slug: S(param_name_str).slugify().s
+			# does it exist
+			if exists == true
 
-			})
+				# output
+				group_obj = app.get('models').apps.build({
+
+						name: param_name_str,
+						description: param_description_str,
+						key: param_key_str,
+						visible: param_visible_str == '1',
+						portal: param_portal_str == '1',
+						slug: S(param_name_str).slugify().s
+
+					})
+
+			else res.redirect '/apps/create?error=no such app folder exists'
 
 		# run it
 		group_obj.save().then -> res.redirect '/apps'

--- a/goddard/handlers/apps/create.coffee
+++ b/goddard/handlers/apps/create.coffee
@@ -27,7 +27,7 @@ module.exports = exports = (app) ->
 		param_portal_str			= req.body.portal
 
 		# validate that the folder exists for the app
-		fs.exists process.env.APP_FOLDER_PATH or '/var/goddard/apps', (exists) ->
+		fs.exists process.env.APP_FOLDER_PATH + "/" + param_key_str, (exists) ->
 
 			# does it exist
 			if exists == true

--- a/goddard/services/node.coffee
+++ b/goddard/services/node.coffee
@@ -54,7 +54,7 @@ module.exports = exports = (app) ->
 	Nodes.saveKey = (node_obj, param_public_key, fn) ->
 
 		# write the key to the autherised hosts
-		fs.appendFile '/home/node/.ssh/authorized_keys', param_public_key + '\n', (err) ->
+		fs.appendFile process.env.AUTHED_KEYS_FILE or '/home/node/.ssh/authorized_keys', param_public_key + '\n', (err) ->
 
 			# handle the error
 			if err


### PR DESCRIPTION
Getting read to put the hub server in a container that can still access:
- The Authed Keys file that are now mounted for use
- The Apps folder to check if the app's folder exists when creating a new one.

@BarryBotha @skibz @jonathanendersby thoughts ?
