### PR TITLE
Updated the app domains to support both goddard.com and mamawifi.com

### DIFF
--- a/goddard/handlers/handshake/apps.coffee
+++ b/goddard/handlers/handshake/apps.coffee
@@ -1,4 +1,5 @@
 # loads all the modules and the subdirs for the app
+### istanbul ignore next ###
 module.exports = exports = (app) ->
 
 	# require the modules
@@ -29,14 +30,12 @@ module.exports = exports = (app) ->
 				# write then output our apps
 				for app_obj in app_objs[0]
 
-					console.dir app_obj
-
 					# generate the domain to use
-					domain_str = app_obj.key + '.goddard.com'
+					domain_str = '~' + app_obj.key + '\.(mamawifi|goddard)\.com'
 
 					# if this is a portal app
 					if app_obj.portal == true
-						domain_str = 'goddard.com'
+						domain_str = '~^(goddard|mamawifi)\.com$'
 
 					# append it
 					public_app_objs.push({


### PR DESCRIPTION
Works with a few of the changes from https://github.com/praekelt/goddard-hub-server/pull/23 and adds both urls in as the domain returned from the server to be setup by the node. This will allow us to ensure all the nodes are always working before or after the mamawifi.com update.
