### PR TITLE
Added a downloads url that also handles login

### DIFF
--- a/goddard/handlers/auth/connect.coffee
+++ b/goddard/handlers/auth/connect.coffee
@@ -21,7 +21,7 @@ module.exports = exports = (app) ->
 			client_id: param_client_id_str,
 			redirect_uri: redirect_uri_str,
 			scope: [ 'email', 'profile' ].join(' '),
-			state: '',
+			state: req.query.return or '',
 			access_type: 'online',
 			approval_prompt: 'auto'
 
@@ -116,8 +116,16 @@ module.exports = exports = (app) ->
 										# all good log them in
 										req.session.logged_in_user_id = user_obj.id
 
-										# set as the logged in user
-										res.redirect('/')
+										# check for redirect ?
+										if req.query.return and req.query.return != 'null'
+
+											# redirect it
+											res.redirect( req.query.return )
+
+										else
+
+											# set as the logged in user
+											res.redirect('/')
 
 									else
 										res.render 'auth/accessdenied', {

--- a/goddard/handlers/downloads.coffee
+++ b/goddard/handlers/downloads.coffee
@@ -33,4 +33,7 @@ module.exports = exports = (app) ->
 					# nothing
 					res.send('no such build was found .. head back <a href="/">here</a>')
 
-		else res.redirect('/connect?return=' + url_str)
+		else 
+
+			# redirect away to actually login
+			res.redirect('/connect?return=' + url_str)

--- a/goddard/handlers/downloads.coffee
+++ b/goddard/handlers/downloads.coffee
@@ -31,7 +31,7 @@ module.exports = exports = (app) ->
 				else 
 
 					# nothing
-					res.send('no such build was found .. head back <a href="/">here</a>')
+					res.status(404).send('no such build was found .. head back <a href="/">here</a>')
 
 		else 
 

--- a/goddard/handlers/downloads.coffee
+++ b/goddard/handlers/downloads.coffee
@@ -1,0 +1,36 @@
+# acts as the homepage for the dashboard
+module.exports = exports = (app) ->
+
+	# require modules
+	fs = require('fs')
+
+	# the homepage for load balancer
+	app.get '/downloads/:year/:month/:file', (req, res) ->
+
+		# redirect
+		url_str = ['', 'downloads', req.params.year, req.params.month, req.params.file].join('/')
+
+		# check if logged in
+		if req.session and req.session.logged_in_user_id
+
+			# base folder
+			base_folder_str = process.env.BUILDS_FOLDER_PATH or '/var/goddard/builds'
+
+			# build the file name
+			file_name = [base_folder_str, req.params.year, req.params.month, req.params.file].join('/')
+
+			# try to login
+			fs.exists file_name, (exists_bool) ->
+
+				# check it
+				if exists_bool == true
+
+					# pipe the file
+					fs.createReadStream(file_name).pipe(res)
+
+				else 
+
+					# nothing
+					res.send('no such build was found .. head back <a href="/">here</a>')
+
+		else res.redirect('/connect?return=' + url_str)

--- a/goddard/handlers/index.coffee
+++ b/goddard/handlers/index.coffee
@@ -4,6 +4,7 @@ module.exports = exports = (app) ->
 
 	# load in our modules
 	require('./home')(app)
+	require('./downloads')(app)
 	require('./handshake')(app)
 	require('./auth')(app)
 	require('./users')(app)


### PR DESCRIPTION
Allows you to download the builds through the web interface that first checks if you are logged in to then download the file. This is the url that users will be notified about when a build is built. Meant to pull this Friday, day got away from me.

Stayed away from a actual token as that would mean we'd have to add a token to each user and that you'll have to somehow send a link with the correct token for each user when sending the link for download. Keep track of tokens seems a bit counter productive.

So the flow here now consists of go to url -> login if not (redirected if not) -> pipe and download the file (pipping just allows local testing).

@jonathanendersby @smn thoughts ?
