### PR TITLE
Updated the warnings to actually parse as JSON

### DIFF
--- a/views/nodes/view.jade
+++ b/views/nodes/view.jade
@@ -11,10 +11,10 @@ block scripts
 		});
 
 block content
-	-if(item_obj.warnings && item_obj.warnings.length > 0)
+	-if(item_obj.warnings && (JSON.parse(item_obj.warnings) || []).length > 0)
 		.alert.alert-warning 
 			ul
-				-each warning_str in ( JSON.stringify(item_obj.warnings || '[]') || [] )
+				-each warning_str in JSON.parse(item_obj.warnings)
 					li #{warning_str}
 	// .alert.alert-danger NODE IS DOWN
 	.row


### PR DESCRIPTION
When we moved to Sqlite to run local unit tests in memory for speed. The warnings field was updated to a string field where JSON is saved in.

This update makes the view first try to parse the JSON and then display the warnings from the array and not just each character in the string
