### PR TITLE
Updated to support NULL for the Parse method

### DIFF
--- a/views/nodes/view.jade
+++ b/views/nodes/view.jade
@@ -11,10 +11,10 @@ block scripts
 		});
 
 block content
-	-if(item_obj.warnings && (JSON.parse(item_obj.warnings) || []).length > 0)
+	-if(item_obj.warnings && (JSON.parse(item_obj.warnings || '[]') || []).length > 0)
 		.alert.alert-warning 
 			ul
-				-each warning_str in JSON.parse(item_obj.warnings)
+				-each warning_str in JSON.parse(item_obj.warnings || '[]')
 					li #{warning_str}
 	// .alert.alert-danger NODE IS DOWN
 	.row


### PR DESCRIPTION
Seems the newest version of Jade throws a actual error for JSON parse and does not just return a "NULL". Updated to default to '[]' if null
